### PR TITLE
add support for batch size more than 1

### DIFF
--- a/shuffle_channel_layer.cpp
+++ b/shuffle_channel_layer.cpp
@@ -30,6 +30,17 @@ void ShuffleChannelLayer<Dtype>::Resize_cpu(Dtype *output, const Dtype *input, i
 }
 
 template <typename Dtype>
+void ShuffleChannelLayer<Dtype>::Reshape(const vector<Blob<Dtype> *> &bottom, const vector<Blob<Dtype> *> &top)
+{
+  int channels_ = bottom[0]->channels();
+  int height_ = bottom[0]->height();
+  int width_ = bottom[0]->width();
+
+  top[0]->Reshape(bottom[0]->num(), channels_, height_, width_);
+
+}
+
+template <typename Dtype>
 void ShuffleChannelLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
                                              const vector<Blob<Dtype>*>& top) {
     const Dtype* bottom_data = bottom[0]->cpu_data();

--- a/shuffle_channel_layer.hpp
+++ b/shuffle_channel_layer.hpp
@@ -17,7 +17,7 @@ public:
     virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
         const vector<Blob<Dtype>*>& top);
     virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
-        const vector<Blob<Dtype>*>& top) {}
+        const vector<Blob<Dtype>*>& top);
     virtual inline const char* type() const { return "ShuffleChannel"; }
 
 protected:


### PR DESCRIPTION
The current version was not taken into account the reshape function for the layer output. 
This led to error when given more than 1 image as an input( batch size > 1).

This is the fix